### PR TITLE
Sseidman/dont reresolve hostname

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1730,7 +1730,11 @@ func (c *Conn) localHostInfo(ctx context.Context) (*HostInfo, error) {
 	port := c.conn.RemoteAddr().(*net.TCPAddr).Port
 
 	// TODO(zariel): avoid doing this here
-	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.host.connectAddress, port: port})
+	// If using a DNS address with a control connection enabled, it's possible that the connectAddress for
+	// the Conn struct does not actually match the IP address of the host that the Conn established
+	// a connection to since the HostDialer has dialed the DNS address again. Update the connectAddress
+	// to the remoteAddress of the connection to avoid mismatch IP's
+	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.conn.RemoteAddr(), port: port})
 	if err != nil {
 		return nil, err
 	}

--- a/conn.go
+++ b/conn.go
@@ -1727,14 +1727,14 @@ func (c *Conn) localHostInfo(ctx context.Context) (*HostInfo, error) {
 		return nil, err
 	}
 
-	port := c.conn.RemoteAddr().(*net.TCPAddr).Port
+	addr := c.conn.RemoteAddr().(*net.TCPAddr)
 
 	// TODO(zariel): avoid doing this here
 	// If using a DNS address with a control connection enabled, it's possible that the connectAddress for
 	// the Conn struct does not actually match the IP address of the host that the Conn established
 	// a connection to since the HostDialer has dialed the DNS address again. Update the connectAddress
 	// to the remoteAddress of the connection to avoid mismatch IP's
-	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: c.conn.RemoteAddr(), port: port})
+	host, err := c.session.hostInfoFromMap(row, &HostInfo{connectAddress: addr.IP, port: addr.Port})
 	if err != nil {
 		return nil, err
 	}

--- a/host_source.go
+++ b/host_source.go
@@ -391,8 +391,10 @@ func (h *HostInfo) IsUp() bool {
 func (h *HostInfo) HostnameAndPort() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	addr, _ := h.connectAddressLocked()
-	h.hostname = addr.String()
+	if h.hostname == "" {
+		addr, _ := h.connectAddressLocked()
+		h.hostname = addr.String()
+	}
 	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
 }
 

--- a/host_source.go
+++ b/host_source.go
@@ -391,10 +391,8 @@ func (h *HostInfo) IsUp() bool {
 func (h *HostInfo) HostnameAndPort() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.hostname == "" {
-		addr, _ := h.connectAddressLocked()
-		h.hostname = addr.String()
-	}
+	addr, _ := h.connectAddressLocked()
+	h.hostname = addr.String()
 	return net.JoinHostPort(h.hostname, strconv.Itoa(h.port))
 }
 


### PR DESCRIPTION
If using a DNS address to establish a connection to a cassandra cluster, it is possible to get a mismatch in `connect_address` and `broadcast_address` for a  single `HostInfo` type if using the default `HostDialer`. This can occur in the following code path:

1. [DNS resolved to IP addresses](https://github.com/gocql/gocql/blob/master/session.go#L191)
2. [Hosts passed to establish control connection](https://github.com/gocql/gocql/blob/master/session.go#L212)
3. [Session dials the host](https://github.com/gocql/gocql/blob/b25227efea00fa55cda33b28629099bafb08b43a/control.go#L240)
4. [DialHost with default HostDialer](https://github.com/gocql/gocql/blob/b25227efea00fa55cda33b28629099bafb08b43a/conn.go#L236)
5. [Use the hostname as dial address instead of IP](https://github.com/gocql/gocql/blob/b25227efea00fa55cda33b28629099bafb08b43a/dial.go#L48)

At step five the `HostInfo` struct has the following form:
```
HostInfo hostname="my-cassandra-dns-address" connectAddress="10.128.189.205" peer="<nil>" 
rpc_address="<nil>" broadcast_address="<nil>" preferred_ip="<nil>" connect_addr="10.128.189.205" 
connect_addr_source="connect_address" port=9042 data_centre="" rack="    " 
host_id="" version="v0.0.0" state=UP num_tokens=0
```

But when attempting to connect the cassandra cluster with the DNS address, it can connect to **any** node in the cluster that the address resolves to. This eventually can result in the following:
```
HostInfo hostname="" connectAddress="10.128.189.205" peer="<nil>" rpc_address="10.128.89.255" 
broadcast_address="10.128.89.255" preferred_ip="<nil>" connect_add    r="10.128.189.205" 
connect_addr_source="connect_address" port=9042 data_centre="us-east" rack="1c" 
host_id="b835f47c-caaf-464f-9f79-aa01eacfa512" version="v3.11.13" state=UP num_tokens=256
```
This `HostInfo` has `connectAddress="10.128.189.205` and `broadcast_address="10.128.89.255"` where both IP addresses are nodes in the cassandra cluster. The `host_id` of the `HostInfo` is for that of the node whose IP is equal to the broadcast_address. The result of this is that although the Connection is supposed to be established to the node whose IP address is equal to the `broadcast_address` it is actually connected to the node whose IP is the `connect_address`. Additionally, the `ring` will now have duplicate hosts:
```
2023/01/11 19:10:49 Session.ring:[10.128.189.205:UP][10.128.93.223:UP][10.128.189.205:UP]
```

I believe this was effected by the following change: https://github.com/gocql/gocql/pull/1632. Nodes were previously added/removed by their `connect_address` (contrary to the PR title), so, using the previous example, if `10.128.189.205` went down, both `Hosts` were removed from the `Ring`. Now, when `10.128.189.205` goes down, only the host whose `broadcast_address` will be removed. So by product of replacing nodes in the cluster, it is possible to end up in a state where a number of clients are attempting to connect to outdated IP addresses that are no longer part of the cluster and that the DNS address no longer resolves to either
